### PR TITLE
Ensure that active property is properly persisted

### DIFF
--- a/src/actions/tag.js
+++ b/src/actions/tag.js
@@ -117,6 +117,7 @@ export function fetchTagDoc (tagid) {
         const markets = JSON.parse(tagDoc.markets);
         const doc = {
           ...tagDoc,
+          active: typeof tagDoc.active === 'boolean' ? tagDoc.active : true,
           markets: formatMarketsToEdit(markets)
         };
         return dispatch(setSelectedTagFromSearch(doc));
@@ -173,10 +174,10 @@ function saveTagDoc (tagDoc) {
 
 export function saveNewConfig () {
   return (dispatch, getState) => {
-    const { taggable: { tagInView: { _id: id, displayName, location, tags, metadata, markets, content, description } } } = getState();
+    const { taggable: { tagInView: { _id: id, displayName, active, location, tags, metadata, markets, content, description } } } = getState();
     // const { _id: id, displayName, location, tags, metadata, markets, content } = tagDoc;
     console.log('markets', markets);
-    const variables = {id, displayName, location, tags, metadata, description, markets: JSON.stringify(formatMarketsToSave(markets)), content};
+    const variables = {id, displayName, active, location, tags, metadata, description, markets: JSON.stringify(formatMarketsToSave(markets)), content};
     console.log('tag update request', variables);
     return graphqlService.query(MUTATION_CREATE_TAG, variables)
       .then(json => {

--- a/src/components/content-editor/index.js
+++ b/src/components/content-editor/index.js
@@ -11,10 +11,11 @@ export default class ContentEditor extends Component {
       ...data,
       markets: data.markets ? data.markets : [],
       content: data.content ? data.content : [],
-      active: data.active ? data.active : true,
+      active: typeof data.active === 'boolean' ? data.active : true,
       description: data.description ? data.description : ''
     };
   }
+
   onSubmit (data) {
     const tagDoc = this.formatFormData(data.formData);
     if (data.errors.length === 0) {


### PR DESCRIPTION
Adds `active` to list of fields to save to graphql endpoint when saving tag data.

Defaults `active` value to `true` where it is not defined.