### PR TITLE
Add missing mime-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "html-webpack-plugin": "^2.15.0",
     "isomorphic-fetch": "^2.2.1",
     "json-loader": "^0.5.4",
+    "mime-types": "^2.1.11",
     "minimist": "^1.2.0",
     "node-zopfli": "^1.4.0",
     "react": "^0.14.7",


### PR DESCRIPTION
This module is used to run deployment script so needs to be in dependencies in package.json