### PR TITLE
Set default values for tag content

### DIFF
--- a/src/actions/tag.js
+++ b/src/actions/tag.js
@@ -118,7 +118,9 @@ export function fetchTagDoc (tagid) {
         const doc = {
           ...tagDoc,
           active: typeof tagDoc.active === 'boolean' ? tagDoc.active : true,
-          markets: formatMarketsToEdit(markets)
+          markets: formatMarketsToEdit(markets),
+          content: tagDoc.content || [],
+          description: tagDoc.description || ''
         };
         return dispatch(setSelectedTagFromSearch(doc));
       });


### PR DESCRIPTION
Validation of the form inputs fails if properties do not have expected types, so we need to default missing propeties to the correct types to allow the form to validate.

Fixes numo-labs/isearch-ui#476
